### PR TITLE
(refactor)(bash): update eks node hostname labels to FQDN

### DIFF
--- a/script/eks
+++ b/script/eks
@@ -17,3 +17,6 @@ kubectl get nodes
 wget https://raw.githubusercontent.com/openebs/litmus/master/hack/rbac.yaml
 kubectl apply -f rbac.yaml
 kubectl create configmap kubeconfig --from-file=/openebs/e2e-eks/.kube/admin.conf -n litmus
+
+## Overwrite node hostname label to use FQDN
+for i in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do kubectl label node $i kubernetes.io/hostname=$i --overwrite=true; done


### PR DESCRIPTION
Changes: 

- Update the hostname labels on EKS nodes

Background: 

- NDM uses the spec.Nodename downward API to attach node details to disk CRs. in EKS, the `kubernetes.io/hostname` uses the node name instead of FQDN which is what is assigned to node resource by Kubernetes. This causes a issue later when this node attribute (name) is picked by Maya to determine the NodeSelector for cstor pool creation

Signed-off-by: ksatchit <karthik.s@openebs.io>